### PR TITLE
Initial files split and gresource

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,5 @@
+subdir('resources')
+
 # Install desktop
 install_data(
   'com.github.gi_lom.dialect.desktop',

--- a/data/resources/dialect.gresource.xml
+++ b/data/resources/dialect.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/gi_lom/dialect">
+    <file>menu.ui</file>
+  </gresource>
+</gresources>

--- a/data/resources/menu.ui
+++ b/data/resources/menu.ui
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <menu id="app-menu">
+    <section>
+      <attribute name="id">help-section</attribute>
+      <item>
+        <attribute name="label" translatable="yes">About Dialect</attribute>
+          <attribute name="action">app.about</attribute>
+      </item>
+    </section>
+  </menu>
+</interface>

--- a/data/resources/meson.build
+++ b/data/resources/meson.build
@@ -1,0 +1,9 @@
+pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
+gnome = import('gnome')
+
+gnome.compile_resources('dialect',
+  'dialect.gresource.xml',
+  gresource_bundle: true,
+  install: true,
+  install_dir: pkgdatadir,
+)

--- a/src/dialect.in
+++ b/src/dialect.in
@@ -1,22 +1,8 @@
 #!@PYTHON@
 
-# dialect.in
-#
 # Copyright 2020 gi-lom
 # Copyright 2020 Rafael Mardojai CM
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import sys

--- a/src/dialect.in
+++ b/src/dialect.in
@@ -1,6 +1,6 @@
 #!@PYTHON@
 
-# blanket.in
+# dialect.in
 #
 # Copyright 2020 gi-lom
 # Copyright 2020 Rafael Mardojai CM

--- a/src/dialect.in
+++ b/src/dialect.in
@@ -1,0 +1,33 @@
+#!@PYTHON@
+
+# blanket.in
+#
+# Copyright 2020 gi-lom
+# Copyright 2020 Rafael Mardojai CM
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import signal
+
+VERSION = '@VERSION@'
+pkgdatadir = '@pkgdatadir@'
+
+sys.path.insert(1, pkgdatadir)
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+if __name__ == '__main__':
+    from dialect import main
+    sys.exit(main.main(VERSION))

--- a/src/dialect.in
+++ b/src/dialect.in
@@ -29,5 +29,11 @@ sys.path.insert(1, pkgdatadir)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 if __name__ == '__main__':
+    import gi
+
+    from gi.repository import Gio
+    resource = Gio.Resource.load(os.path.join(pkgdatadir, 'dialect.gresource'))
+    resource._register()
+
     from dialect import main
     sys.exit(main.main(VERSION))

--- a/src/main.py
+++ b/src/main.py
@@ -1,20 +1,6 @@
-# main.py
-#
 # Copyright 2020 gi-lom
 # Copyright 2020 Mufeed Ali
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # Initial setup
 import json

--- a/src/main.py
+++ b/src/main.py
@@ -187,7 +187,7 @@ class MainWindow(Gtk.ApplicationWindow):
         ClipboardButton.connect("clicked", self.UIPaperclip)
 
         ### Menu button
-        Builder = Gtk.Builder.new_from_string(MenuBuilder, -1) 
+        Builder = Gtk.Builder.new_from_string(MenuBuilder, -1)
         Menu = Builder.get_object("app-menu")
         MenuButton = Gtk.MenuButton()
         MenuButton.set_direction(Gtk.ArrowType.NONE)
@@ -370,7 +370,7 @@ class MainWindow(Gtk.ApplicationWindow):
             self.VoiceSpinner.start()
             threading.Thread(target=self.VoiceDownload,
                              args=(SecondText, SecondLanguageVoice)).start()
-            
+
     def VoiceDownload(self, Text, Lang):
         FileToPlay = BytesIO()
         try:
@@ -607,9 +607,7 @@ class Dialect(Gtk.Application):
         GLib.set_prgname('com.github.gi_lom.dialect')
 
 
-def main():
-    # Final part, run the Application
+def main(version):
+    # Run the Application
     app = Dialect()
     return app.run(sys.argv)
-
-main()

--- a/src/main.py
+++ b/src/main.py
@@ -28,21 +28,6 @@ ButtonNumLanguages = 3  # number of language buttons
 XdgConfigHome = GLib.get_user_config_dir()
 SettingsFile = os.path.join(XdgConfigHome, 'dialect', 'settings.json')
 
-MenuBuilder = """
-<?xml version="1.0" encoding="UTF-8"?>
-<interface>
-    <menu id="app-menu">
-        <section>
-            <attribute name="id">help-section</attribute>
-            <item>
-                <attribute name="label" translatable="yes">About Dialect</attribute>
-                <attribute name="action">app.about</attribute>
-            </item>
-        </section>
-    </menu>
-</interface>
-"""
-
 
 # Main part
 class MainWindow(Gtk.ApplicationWindow):
@@ -187,7 +172,7 @@ class MainWindow(Gtk.ApplicationWindow):
         ClipboardButton.connect("clicked", self.UIPaperclip)
 
         ### Menu button
-        Builder = Gtk.Builder.new_from_string(MenuBuilder, -1)
+        Builder = Gtk.Builder.new_from_resource("/com/github/gi_lom/dialect/menu.ui")
         Menu = Builder.get_object("app-menu")
         MenuButton = Gtk.MenuButton()
         MenuButton.set_direction(Gtk.ArrowType.NONE)

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,20 @@
-#!/usr/bin/env python3
+# main.py
+#
+# Copyright 2020 gi-lom
+# Copyright 2020 Mufeed Ali
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Initial setup
 import json

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,26 @@
+pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
+moduledir = join_paths(pkgdatadir, 'dialect')
 
-# Install dialect.py in bindir
-install_data('dialect.py', rename: 'dialect', install_dir: get_option('bindir'))
+python = import('python')
+
+conf = configuration_data()
+conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('VERSION', meson.project_version())
+conf.set('pkgdatadir', pkgdatadir)
+
+# Generate dialect bin
+configure_file(
+  input: 'dialect.in',
+  output: 'dialect',
+  configuration: conf,
+  install: true,
+  install_dir: get_option('bindir')
+)
+
+# Python sources
+sources = [
+  '__init__.py',
+  'main.py',
+]
+# Install sources
+install_data(sources, install_dir: moduledir)


### PR DESCRIPTION
What does this PR?

- Implements the meson setup needed to split source files
  - Generates the bin file from `dialect.in`.
  - Install all the sources listed in the meson file (right now only `main.py`).
  - The bin file imports `main.py` and run the app
- Implements the code to start using GResource. Currently we only have the `menu.ui` resource for the app menu.
- Also added license/copyright notice to every python file.

Any other change I can do in this PR?

cc @fushinari 