### PR TITLE
Dynamic modules

### DIFF
--- a/data/com.github.gi_lom.dialect.gschema.xml
+++ b/data/com.github.gi_lom.dialect.gschema.xml
@@ -27,9 +27,8 @@
     <key type="s" name="backend-settings">
         <default>"{}"</default>
     </key>
-    <key type="i" name="tts">
-        <!-- 0 = Disabled | 1 = Google TTS -->
-        <default>1</default>
+    <key type="s" name="tts-name">
+        <default>"google"</default>
     </key>
     <key type="as" name="google-src-langs">
         <!-- Deprecated option -->

--- a/data/com.github.gi_lom.dialect.gschema.xml
+++ b/data/com.github.gi_lom.dialect.gschema.xml
@@ -18,26 +18,37 @@
         <default>0</default>
     </key>
     <key type="i" name="backend">
-        <!-- 0 = Google Translate | 1 = LibreTranslate -->
+        <!-- Deprecated option -->
         <default>0</default>
+    </key>
+    <key type="s" name="backend-name">
+        <default>"google"</default>
+    </key>
+    <key type="s" name="backend-settings">
+        <default>"{}"</default>
     </key>
     <key type="i" name="tts">
         <!-- 0 = Disabled | 1 = Google TTS -->
         <default>1</default>
     </key>
     <key type="as" name="google-src-langs">
+        <!-- Deprecated option -->
         <default>["en", "fr", "es", "de"]</default>
     </key>
     <key type="as" name="google-dest-langs">
+        <!-- Deprecated option -->
         <default>["fr", "es", "de", "en"]</default>
     </key>
     <key type="as" name="libretranslate-src-langs">
+        <!-- Deprecated option -->
         <default>["en", "fr", "es", "de"]</default>
     </key>
     <key type="as" name="libretranslate-dest-langs">
+        <!-- Deprecated option -->
         <default>["fr", "es", "de", "en"]</default>
     </key>
     <key type="s" name="libretranslate-instance">
+        <!-- Deprecated option -->
         <default>"translate.astian.org"</default>
     </key>
   </schema>

--- a/data/com.github.gi_lom.dialect.gschema.xml
+++ b/data/com.github.gi_lom.dialect.gschema.xml
@@ -19,7 +19,8 @@
     </key>
     <key type="i" name="backend">
         <!-- Deprecated option -->
-        <default>0</default>
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>-1</default>
     </key>
     <key type="s" name="backend-name">
         <default>"google"</default>
@@ -32,23 +33,28 @@
     </key>
     <key type="as" name="google-src-langs">
         <!-- Deprecated option -->
-        <default>["en", "fr", "es", "de"]</default>
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>[]</default>
     </key>
     <key type="as" name="google-dest-langs">
         <!-- Deprecated option -->
-        <default>["fr", "es", "de", "en"]</default>
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>[]</default>
     </key>
     <key type="as" name="libretranslate-src-langs">
         <!-- Deprecated option -->
-        <default>["en", "fr", "es", "de"]</default>
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>[]</default>
     </key>
     <key type="as" name="libretranslate-dest-langs">
         <!-- Deprecated option -->
-        <default>["fr", "es", "de", "en"]</default>
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>[]</default>
     </key>
     <key type="s" name="libretranslate-instance">
         <!-- Deprecated option -->
-        <default>"translate.astian.org"</default>
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>""</default>
     </key>
   </schema>
 </schemalist>

--- a/src/main.py
+++ b/src/main.py
@@ -13,12 +13,12 @@ gi.require_version('Gtk', '3.0')
 gi.require_version('Gst', '1.0')
 gi.require_version('Handy', '1')
 
-from gi.repository import Gdk, Gio, GLib, Gtk, Gst, Handy
+from gi.repository import Gdk, Gio, GLib, Gst, Gtk, Handy
 
 from dialect.define import APP_ID, RES_PATH
-from dialect.window import DialectWindow
 from dialect.preferences import DialectPreferencesWindow
 from dialect.settings import Settings
+from dialect.window import DialectWindow
 
 
 class Dialect(Gtk.Application):

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from gi.repository import Gdk, Gio, GLib, Gtk, Gst, Handy
 from dialect.define import APP_ID, RES_PATH
 from dialect.window import DialectWindow
 from dialect.preferences import DialectPreferencesWindow
+from dialect.settings import Settings
 
 
 class Dialect(Gtk.Application):
@@ -33,7 +34,6 @@ class Dialect(Gtk.Application):
         self.window = None
         self.launch_text = ''
         self.launch_langs = {}
-        self.settings = Gio.Settings.new(APP_ID)
 
         # Add command line options
         self.add_main_option('text', b't', GLib.OptionFlags.NONE,
@@ -51,8 +51,7 @@ class Dialect(Gtk.Application):
                 # Translators: Do not translate the app name!
                 title=_('Dialect'),
                 text=self.launch_text,
-                langs=self.launch_langs,
-                settings=self.settings
+                langs=self.launch_langs
             )
         self.window.present()
 
@@ -101,7 +100,7 @@ class Dialect(Gtk.Application):
         """ Setup menu actions """
 
         self.pronunciation_action = Gio.SimpleAction.new_stateful(
-            'pronunciation', None, self.settings.get_value('show-pronunciation')
+            'pronunciation', None, Settings.get().get_value('show-pronunciation')
         )
         self.pronunciation_action.connect('change-state', self.on_pronunciation)
         self.add_action(self.pronunciation_action)
@@ -127,7 +126,7 @@ class Dialect(Gtk.Application):
     def on_pronunciation(self, action, value):
         """ Update show pronunciation setting """
         action.set_state(value)
-        self.settings.set_boolean('show-pronunciation', value)
+        Settings.get().set_boolean('show-pronunciation', value)
 
         # Update UI
         if self.window.trans_src_pron is not None:
@@ -137,7 +136,7 @@ class Dialect(Gtk.Application):
 
     def on_preferences(self, _action, _param):
         """ Show preferences window """
-        window = DialectPreferencesWindow(self.window, settings=self.settings)
+        window = DialectPreferencesWindow(self.window)
         window.set_transient_for(self.window)
         window.present()
 
@@ -145,8 +144,8 @@ class Dialect(Gtk.Application):
         """Launch the Keyboard Shortcuts window."""
         builder = Gtk.Builder.new_from_resource(f'{RES_PATH}/shortcuts-window.ui')
         translate_shortcut = builder.get_object('translate_shortcut')
-        translate_shortcut.set_visible(not self.settings.get_boolean('live-translation'))
-        if self.settings.get_value('translate-accel'):
+        translate_shortcut.set_visible(not Settings.get().get_boolean('live-translation'))
+        if Settings.get().get_value('translate-accel'):
             translate_shortcut.set_property('accelerator', 'Return')
         else:
             translate_shortcut.set_property('accelerator', '<Primary>Return')

--- a/src/main.py
+++ b/src/main.py
@@ -100,7 +100,7 @@ class Dialect(Gtk.Application):
         """ Setup menu actions """
 
         self.pronunciation_action = Gio.SimpleAction.new_stateful(
-            'pronunciation', None, Settings.get().get_value('show-pronunciation')
+            'pronunciation', None, Settings.get().show_pronunciation_value
         )
         self.pronunciation_action.connect('change-state', self.on_pronunciation)
         self.add_action(self.pronunciation_action)
@@ -126,7 +126,7 @@ class Dialect(Gtk.Application):
     def on_pronunciation(self, action, value):
         """ Update show pronunciation setting """
         action.set_state(value)
-        Settings.get().set_boolean('show-pronunciation', value)
+        Settings.get().show_pronunciation = value
 
         # Update UI
         if self.window.trans_src_pron is not None:
@@ -144,11 +144,8 @@ class Dialect(Gtk.Application):
         """Launch the Keyboard Shortcuts window."""
         builder = Gtk.Builder.new_from_resource(f'{RES_PATH}/shortcuts-window.ui')
         translate_shortcut = builder.get_object('translate_shortcut')
-        translate_shortcut.set_visible(not Settings.get().get_boolean('live-translation'))
-        if Settings.get().get_value('translate-accel'):
-            translate_shortcut.set_property('accelerator', 'Return')
-        else:
-            translate_shortcut.set_property('accelerator', '<Primary>Return')
+        translate_shortcut.set_visible(not Settings.get().live_translation)
+        translate_shortcut.set_property('accelerator', Settings.get().translate_accel)
         shortcuts_window = builder.get_object('shortcuts')
         shortcuts_window.set_transient_for(self.window)
         shortcuts_window.show()

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,8 +15,6 @@ run_target('run',
 )
 
 subdir('search_provider')
-subdir('translators')
-subdir('tts')
 
 # Python sources
 sources = [
@@ -30,3 +28,7 @@ sources = [
 ]
 # Install sources
 install_data(sources, install_dir: moduledir)
+
+# Install translators and tts providers
+install_subdir('translators', install_dir: moduledir)
+install_subdir('tts', install_dir: moduledir)

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ sources = [
   'window.py',
   'preferences.py',
   'lang_selector.py',
+  'settings.py',
 ]
 # Install sources
 install_data(sources, install_dir: moduledir)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -69,21 +69,6 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
                                      Handy.ValueObject.dup_string)
 
         # Bind preferences with GSettings
-        self.dark_mode.set_active(Settings.get().get_boolean('dark-mode'))
-        self.dark_mode.connect('notify::active', self._toggle_dark_mode)
-
-        self.live_translation.set_active(Settings.get().get_boolean('live-translation'))
-        self.live_translation.connect('notify::active', self._toggle_live_translation)
-
-        self.src_auto.set_active(Settings.get().get_boolean('src-auto'))
-        self.src_auto.connect('notify::active', self._toggle_src_auto)
-
-        self.backend.set_active(Settings.get().get_boolean('backend'))
-        self.backend.connect('notify::active', self._toggle_backend)
-
-        self.dark_mode.set_active(Settings.get().get_boolean('dark-mode'))
-        self.dark_mode.connect('notify::active', self._toggle_dark_mode)
-
         Settings.get().bind('live-translation', self.live_translation, 'active',
                            Gio.SettingsBindFlags.DEFAULT)
         Settings.get().bind('translate-accel', self.translate_accel,
@@ -95,6 +80,9 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
 
         # Setup TTS
         self.tts.set_active(bool(Settings.get().get_int('tts')))
+
+        # Toggle dark mode
+        self.dark_mode.connect('notify::active', self._toggle_dark_mode)
 
         # Set translate accel sensitivity by live translation state
         self.translate_accel.set_sensitive(not self.live_translation.get_active())
@@ -156,7 +144,6 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
         gtk_settings = Gtk.Settings.get_default()
         active = switch.get_active()
         gtk_settings.set_property('gtk-application-prefer-dark-theme', active)
-        Settings.get().set_boolean('dark-mode', active)
 
     def _toggle_accel_pref(self, switch, _active):
         self.translate_accel.set_sensitive(not switch.get_active())

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -10,9 +10,9 @@ from gettext import gettext as _
 from gi.repository import Gio, GLib, GObject, Gtk, Handy
 
 from dialect.define import RES_PATH
+from dialect.settings import Settings
 from dialect.translators import TRANSLATORS
 from dialect.tts import TTS
-from dialect.settings import Settings
 
 
 @Gtk.Template(resource_path=f'{RES_PATH}/preferences.ui')
@@ -60,9 +60,9 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
                                              Handy.ValueObject.dup_string)
 
         # Setup backends combo row
-        self.backend_model = Gio.ListStore.new(TranslatorObject)
+        self.backend_model = Gio.ListStore.new(BackendObject)
         backend_options = [
-            TranslatorObject(translator.name, translator.prettyname) for translator in TRANSLATORS.values()
+            BackendObject(translator.name, translator.prettyname) for translator in TRANSLATORS.values()
         ]
         selected_backend_index = 0
         for index, value in enumerate(backend_options):
@@ -70,7 +70,7 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
             if value.name == Settings.get().backend:
                 selected_backend_index = index
         self.backend.bind_name_model(self.backend_model,
-                                     TranslatorObject.get_name)
+                                     BackendObject.get_name)
 
         # Bind preferences with GSettings
         Settings.get().bind('live-translation', self.live_translation, 'active',
@@ -250,7 +250,7 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
 
         GLib.idle_add(spinner_end)
 
-class TranslatorObject(GObject.Object):
+class BackendObject(GObject.Object):
     name = None
     prettyname = None
 

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -11,6 +11,7 @@ from gi.repository import Gio, GLib, Gtk, Handy
 
 from dialect.define import RES_PATH
 from dialect.translators import TRANSLATORS
+from dialect.tts import TTS
 from dialect.settings import Settings
 
 
@@ -79,7 +80,7 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
                             Gio.SettingsBindFlags.DEFAULT)
 
         # Setup TTS
-        self.tts.set_active(Settings.get().tts)
+        self.tts.set_active(Settings.get().tts != '')
 
         # Toggle dark mode
         self.dark_mode.connect('notify::active', self._toggle_dark_mode)
@@ -153,17 +154,23 @@ class DialectPreferencesWindow(Handy.PreferencesWindow):
         self.translate_accel.set_sensitive(not switch.get_active())
 
     def _toggle_tts(self, switch, _active):
-        value = int(switch.get_active())
+        value = ''
+        if switch.get_active() and len(TTS) >= 1:
+            tts = list(TTS.keys())
+            value = str(tts[0])
+
         self.parent.src_voice_btn.set_sensitive(False)
         self.parent.src_voice_btn.set_visible(switch.get_active())
         self.parent.dest_voice_btn.set_sensitive(False)
         self.parent.dest_voice_btn.set_visible(switch.get_active())
+
+        Settings.get().tts = value
+
         if switch.get_active():
             threading.Thread(
                 target=self.parent.load_lang_speech,
                 daemon=True
             ).start()
-        Settings.get().tts_value = value
 
     def _switch_backends(self, row, _value):
         backend = self._backend_options[row.get_selected_index()][0]

--- a/src/search_provider/search_provider.in
+++ b/src/search_provider/search_provider.in
@@ -11,7 +11,9 @@ import threading
 
 from dbus.mainloop.glib import DBusGMainLoop
 from gi.repository import GLib, Gio
+
 from dialect.translators import TRANSLATORS
+from dialect.settings import Settings
 
 APP_ID = 'com.github.gi_lom.dialect'
 
@@ -32,8 +34,7 @@ class TranslateService(dbus.service.Object):
 
         # Translations running now
         self.translations = dict()
-        self.settings = Gio.Settings.new(APP_ID)
-        self.settings.connect('changed', self._on_settings_changed)
+        Settings.get().connect('changed', self._on_settings_changed)
 
         self.dest_language = None
         self.active_thread = None
@@ -122,8 +123,8 @@ class TranslateService(dbus.service.Object):
 
         # set dest_language to last used language and src_language to auto detection
         src_language = 'auto'
-        src_language_saved = self.settings.get_strv(f'{self.translator.name}-src-langs')[0]
-        dest_language = self.settings.get_strv(f'{self.translator.name}-dest-langs')[0]
+        src_language_saved = Settings.get().get_strv(f'{self.translator.name}-src-langs')[0]
+        dest_language = Settings.get().get_strv(f'{self.translator.name}-dest-langs')[0]
 
         if self.trans_queue:
             self.trans_queue.pop(0)
@@ -184,20 +185,20 @@ class TranslateService(dbus.service.Object):
                 return
 
     def is_live_enabled(self):
-        return self.settings.get_boolean('live-translation')
+        return Settings.get().get_boolean('live-translation')
 
     def _get_translator(self):
-        backend = self.settings.get_int('backend')
+        backend = Settings.get().get_int('backend')
         if TRANSLATORS[backend].supported_features['change-instance']:
             translator = TRANSLATORS[backend](
-                base_url=self.settings.get_string(f'{TRANSLATORS[backend].name}-instance')
+                base_url=Settings.get().get_string(f'{TRANSLATORS[backend].name}-instance')
             )
         else:
             translator = TRANSLATORS[backend]()
         return translator
 
     def _on_settings_changed(self, _settings, key):
-        backend = self.settings.get_int('backend')
+        backend = Settings.get().get_int('backend')
         if key == 'backend' or key == f'{TRANSLATORS[backend].name}-instance':
             self.translator = self._get_translator()
 

--- a/src/search_provider/search_provider.in
+++ b/src/search_provider/search_provider.in
@@ -123,8 +123,8 @@ class TranslateService(dbus.service.Object):
 
         # set dest_language to last used language and src_language to auto detection
         src_language = 'auto'
-        src_language_saved = Settings.get().get_strv(f'{self.translator.name}-src-langs')[0]
-        dest_language = Settings.get().get_strv(f'{self.translator.name}-dest-langs')[0]
+        src_language_saved = Settings.get().get_src_langs(self.translator.name)[0]
+        dest_language = Settings.get().get_dest_langs(self.translator.name)[0]
 
         if self.trans_queue:
             self.trans_queue.pop(0)
@@ -185,10 +185,10 @@ class TranslateService(dbus.service.Object):
                 return
 
     def is_live_enabled(self):
-        return Settings.get().get_boolean('live-translation')
+        return Settings.get().live_translation
 
     def _get_translator(self):
-        backend = Settings.get().get_int('backend')
+        backend = Settings.get().backend
         if TRANSLATORS[backend].supported_features['change-instance']:
             translator = TRANSLATORS[backend](
                 base_url=Settings.get().get_string(f'{TRANSLATORS[backend].name}-instance')
@@ -198,8 +198,8 @@ class TranslateService(dbus.service.Object):
         return translator
 
     def _on_settings_changed(self, _settings, key):
-        backend = Settings.get().get_int('backend')
-        if key == 'backend' or key == f'{TRANSLATORS[backend].name}-instance':
+        backend = Settings.get().backend
+        if key == 'backend-name' or key == f'backend-settings':
             self.translator = self._get_translator()
 
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,29 @@
+from gi.repository import Gio
+
+from dialect.define import APP_ID
+
+
+class Settings(Gio.Settings):
+    """
+    Dialect settings handler
+    """
+
+    instance = None
+
+    def __init__(self):
+        Gio.Settings.__init__(self)
+
+    @staticmethod
+    def new():
+        """Create a new instance of Settings."""
+        g_settings = Gio.Settings.new(APP_ID)
+        g_settings.__class__ = Settings
+        return g_settings
+
+    @staticmethod
+    def get():
+        """Return an active instance of Settings."""
+        if Settings.instance is None:
+            Settings.instance = Settings.new()
+
+        return Settings.instance

--- a/src/settings.py
+++ b/src/settings.py
@@ -113,6 +113,8 @@ class Settings(Gio.Settings):
         value = None
 
         try:
+            # Dialect 1.2.0 and below used the backend key and
+            # stored the index of the chosen backend as an int.
             value = self.get_int('backend')
         except Exception:
             pass
@@ -139,11 +141,13 @@ class Settings(Gio.Settings):
         :param name: name of backend
         :type name: string
         """
-        self._delete_int_key('backend')
+        self._delete_int_key('backend')  # Set deprecated key to unused state.
         self.set_string('backend-name', name)
 
     def get_instance_url(self, backend):
         try:
+            # Dialect 1.2.0 and below used separate keys for each
+            # backend-specific setting.
             instance_url = self.get_string(f'{backend}-instance')
             if instance_url:
                 return instance_url
@@ -158,19 +162,21 @@ class Settings(Gio.Settings):
         return TRANSLATORS[backend].instance_url
 
     def set_instance_url(self, backend, instance_url):
-        self._delete_str_key(f'{backend}-instance')
+        self._delete_str_key(f'{backend}-instance')  # Set deprecated key to unused state.
         settings = self._backend_settings(backend)
         settings[backend]['instance-url'] = instance_url
         self.backend_settings = settings
 
     def reset_instance_url(self, backend):
-        self._delete_str_key(f'{backend}-instance')
+        self._delete_str_key(f'{backend}-instance')  # Set deprecated key to unused state.
         settings = self._backend_settings()
         settings[backend]['instance-url'] = TRANSLATORS[backend].instance_url
         self.backend_settings = settings
 
     def get_dest_langs(self, backend):
         try:
+            # Dialect 1.2.0 and below used separate keys for each
+            # backend-specific setting.
             dest_langs = list(self.get_value(f'{backend}-dest-langs'))
             if dest_langs:
                 return dest_langs
@@ -185,19 +191,21 @@ class Settings(Gio.Settings):
         return TRANSLATORS[backend].dest_langs
 
     def set_dest_langs(self, backend, langs):
-        self._delete_arr_key(f'{backend}-dest-langs')
+        self._delete_arr_key(f'{backend}-dest-langs')  # Set deprecated key to unused state.
         settings = self._backend_settings(backend)
         settings[backend]['dest-langs'] = langs
         self.backend_settings = settings
 
     def reset_dest_langs(self, backend):
-        self._delete_arr_key(f'{backend}-dest-langs')
+        self._delete_arr_key(f'{backend}-dest-langs')  # Set deprecated key to unused state.
         settings = self._backend_settings(backend)
         settings[backend]['dest-langs'] = TRANSLATORS[backend].dest_langs
         self.backend_settings = settings
 
     def get_src_langs(self, backend):
         try:
+            # Dialect 1.2.0 and below used separate keys for each
+            # backend-specific setting.
             src_langs = list(self.get_value(f'{backend}-src-langs'))
             if src_langs:
                 return src_langs
@@ -212,13 +220,13 @@ class Settings(Gio.Settings):
         return TRANSLATORS[backend].src_langs
 
     def set_src_langs(self, backend, langs):
-        self._delete_arr_key(f'{backend}-src-langs')
+        self._delete_arr_key(f'{backend}-src-langs')  # Set deprecated key to unused state.
         settings = self._backend_settings(backend)
         settings[backend]['src-langs'] = langs
         self.backend_settings = settings
 
     def reset_src_langs(self, backend):
-        self._delete_arr_key(f'{backend}-src-langs')
+        self._delete_arr_key(f'{backend}-src-langs')  # Set deprecated key to unused state.
         settings = self._backend_settings(backend)
         settings[backend]['src-langs'] = TRANSLATORS[backend].src_langs
         self.backend_settings = settings
@@ -246,32 +254,33 @@ class Settings(Gio.Settings):
 
     def _delete_arr_key(self, key):
         try:
-            self.get_value(key)
-            self.set_value(key,
-                           GLib.Variant('as', []))
+            val = self.get_strv(key)
+            if val != []:
+                self.set_value(key, GLib.Variant('as', []))
         except Exception:
             pass
 
     def _delete_enum_key(self, key):
         try:
-            self.get_enum(key)
-            self.set_enum(key,
-                          -1)
+            val = self.get_enum(key)
+            if val > -1:
+                self.set_enum(key, -1)
         except Exception:
             pass
 
     def _delete_int_key(self, key):
         try:
-            self.get_int(key)
-            self.set_int(key,
-                         -1)
+            val = self.get_int(key)
+            if val > -1:
+                self.set_int(key, -1)
         except Exception:
             pass
 
     def _delete_str_key(self, key):
         try:
-            self.get_value(key)
-            self.set_value(key,
-                           GLib.Variant('s', ''))
+            val = self.get_string(key)
+            if val != '':
+                self.set_value(key,
+                               GLib.Variant('s', ''))
         except Exception:
             pass

--- a/src/settings.py
+++ b/src/settings.py
@@ -7,7 +7,11 @@ import json
 from gi.repository import Gio, GLib
 
 from dialect.define import APP_ID
-from dialect.translators import check_backend_availability, get_fallback_backend_name, TRANSLATORS
+from dialect.translators import (
+    check_backend_availability,
+    get_fallback_backend_name,
+    TRANSLATORS
+)
 from dialect.tts import TTS
 
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,6 +8,7 @@ from gi.repository import Gio, GLib
 
 from dialect.define import APP_ID
 from dialect.translators import check_backend_availability, get_fallback_backend_name, TRANSLATORS
+from dialect.tts import TTS
 
 
 class Settings(Gio.Settings):
@@ -55,17 +56,16 @@ class Settings(Gio.Settings):
     @property
     def tts(self):
         """Return the user's preferred TTS service."""
-        return bool(self.tts_value)
+        value = self.get_string('tts-name')
+        if value not in TTS.keys():
+            value = ''
+            self.tts = value
+        return value
 
-    @property
-    def tts_value(self):
-        """Return the user's preferred TTS service value."""
-        return self.get_int('tts')
-
-    @tts_value.setter
-    def tts_value(self, value):
-        """Set the user's preferred TTS service value."""
-        self.set_int('tts', value)
+    @tts.setter
+    def tts(self, value):
+        """Set the user's preferred TTS service."""
+        self.set_string('tts-name', value)
 
     @property
     def dark_mode(self):

--- a/src/translators/__init__.py
+++ b/src/translators/__init__.py
@@ -17,9 +17,3 @@ def get_fallback_backend_name():
     if TRANSLATORS:
         return list(TRANSLATORS.keys())[0]
     return None
-
-def get_fallback_backend():
-    backend_name = get_fallback_backend_name()
-    if backend_name:
-        return TRANSLATORS[backend_name]
-    return None

--- a/src/translators/__init__.py
+++ b/src/translators/__init__.py
@@ -2,8 +2,16 @@ import pkgutil
 import importlib
 
 TRANSLATORS = {}
-for importer, modname, ispkg in pkgutil.iter_modules(__path__):
+for _importer, modname, _ispkg in pkgutil.iter_modules(__path__):
     if modname != 'basetrans':
         modclass = importlib.import_module('dialect.translators.' + modname).Translator
         TRANSLATORS[modclass.name] = modclass
 
+def check_backend_availability(backend_name):
+    if backend_name in TRANSLATORS.keys():
+        return True
+
+    return False
+
+def get_fallback_backend():
+    return list(TRANSLATORS.keys())[0]

--- a/src/translators/__init__.py
+++ b/src/translators/__init__.py
@@ -1,5 +1,5 @@
-import pkgutil
 import importlib
+import pkgutil
 
 TRANSLATORS = {}
 for _importer, modname, _ispkg in pkgutil.iter_modules(__path__):

--- a/src/translators/__init__.py
+++ b/src/translators/__init__.py
@@ -13,5 +13,13 @@ def check_backend_availability(backend_name):
 
     return False
 
+def get_fallback_backend_name():
+    if TRANSLATORS:
+        return list(TRANSLATORS.keys())[0]
+    return None
+
 def get_fallback_backend():
-    return list(TRANSLATORS.keys())[0]
+    backend_name = get_fallback_backend_name()
+    if backend_name:
+        return TRANSLATORS[backend_name]
+    return None

--- a/src/translators/__init__.py
+++ b/src/translators/__init__.py
@@ -1,7 +1,9 @@
-from dialect.translators.gtrans import GTranslator
-from dialect.translators.libretrans import LibreTranslator
+import pkgutil
+import importlib
 
-TRANSLATORS = [
-    GTranslator,
-    LibreTranslator,
-]
+TRANSLATORS = {}
+for importer, modname, ispkg in pkgutil.iter_modules(__path__):
+    if modname != 'basetrans':
+        modclass = importlib.import_module('dialect.translators.' + modname).Translator
+        TRANSLATORS[modclass.name] = modclass
+

--- a/src/translators/basetrans.py
+++ b/src/translators/basetrans.py
@@ -14,6 +14,9 @@ class TranslatorBase:
         'pronunciation': False,
         'change-instance': False,
     }
+    instance_url = ''
+    src_langs = ['en', 'fr', 'es', 'de']
+    dest_langs = ['fr', 'es', 'de', 'en']
 
     @staticmethod
     def validate_instance_url(url):

--- a/src/translators/gtrans.py
+++ b/src/translators/gtrans.py
@@ -2,12 +2,12 @@
 # Copyright 2021 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from googletrans import LANGUAGES, Translator
+from googletrans import LANGUAGES, Translator as GoogleTranslator
 
 from dialect.translators.basetrans import TranslatorBase, TranslationError, Translation
 
 
-class GTranslator(TranslatorBase):
+class Translator(TranslatorBase):
     name = 'google'
     prettyname = 'Google Translate'
     history = []
@@ -19,7 +19,7 @@ class GTranslator(TranslatorBase):
     }
 
     def __init__(self, **kwargs):
-        self._translator = Translator()
+        self._translator = GoogleTranslator()
 
     def detect(self, src_text):
         try:

--- a/src/translators/libretrans.py
+++ b/src/translators/libretrans.py
@@ -7,7 +7,7 @@ import httpx
 from dialect.translators.basetrans import Detected, TranslatorBase, TranslationError, Translation
 
 
-class LibreTranslator(TranslatorBase):
+class Translator(TranslatorBase):
     name = 'libretranslate'
     prettyname = 'LibreTranslate'
     client = None

--- a/src/translators/libretrans.py
+++ b/src/translators/libretrans.py
@@ -18,11 +18,11 @@ class Translator(TranslatorBase):
         'pronunciation': False,
         'change-instance': True,
     }
-    base_url = ''
+    instance_url = 'translate.astian.org'
 
     def __init__(self, base_url=None, **kwargs):
         if base_url is not None:
-            self.base_url = base_url
+            self.instance_url = base_url
 
         self.client = httpx.Client()
 
@@ -33,21 +33,21 @@ class Translator(TranslatorBase):
 
     @property
     def detect_url(self):
-        if self.base_url.startswith('localhost:'):
-            return 'http://' + self.base_url + '/detect'
-        return 'https://' + self.base_url + '/detect'
+        if self.instance_url.startswith('localhost:'):
+            return 'http://' + self.instance_url + '/detect'
+        return 'https://' + self.instance_url + '/detect'
 
     @property
     def translate_url(self):
-        if self.base_url.startswith('localhost:'):
-            return 'http://' + self.base_url + '/translate'
-        return 'https://' + self.base_url + '/translate'
+        if self.instance_url.startswith('localhost:'):
+            return 'http://' + self.instance_url + '/translate'
+        return 'https://' + self.instance_url + '/translate'
 
     @property
     def lang_url(self):
-        if self.base_url.startswith('localhost:'):
-            return 'http://' + self.base_url + '/languages'
-        return 'https://' + self.base_url + '/languages'
+        if self.instance_url.startswith('localhost:'):
+            return 'http://' + self.instance_url + '/languages'
+        return 'https://' + self.instance_url + '/languages'
 
     @staticmethod
     def validate_instance_url(url):

--- a/src/translators/meson.build
+++ b/src/translators/meson.build
@@ -1,9 +1,0 @@
-# Python sources
-sources = [
-  '__init__.py',
-  'basetrans.py',
-  'gtrans.py',
-  'libretrans.py',
-]
-# Install sources
-install_data(sources, install_dir: join_paths(moduledir, 'translators'))

--- a/src/tts/__init__.py
+++ b/src/tts/__init__.py
@@ -1,5 +1,5 @@
-import pkgutil
 import importlib
+import pkgutil
 
 TTS = {}
 for _importer, modname, _ispkg in pkgutil.iter_modules(__path__):

--- a/src/tts/__init__.py
+++ b/src/tts/__init__.py
@@ -1,5 +1,9 @@
-from dialect.tts.gtts import GTextToSpeech
+import pkgutil
+import importlib
 
-TTS = [
-    GTextToSpeech,
-]
+TTS = {}
+for _importer, modname, _ispkg in pkgutil.iter_modules(__path__):
+    if modname != 'basetts':
+        modclass = importlib.import_module('dialect.tts.' + modname).TextToSpeech
+        TTS[modclass.name] = modclass
+

--- a/src/tts/basetts.py
+++ b/src/tts/basetts.py
@@ -7,7 +7,7 @@ class TextToSpeechBase:
     prettyname = ''
     languages = ['en']
 
-    def download_voice(self, text, language):
+    def download_voice(self, text, language, file):
         pass
 
 

--- a/src/tts/basetts.py
+++ b/src/tts/basetts.py
@@ -18,4 +18,3 @@ class TextToSpeechError(Exception):
         self.cause = cause
         self.message = message
         super().__init__(self.message)
-

--- a/src/tts/gtts.py
+++ b/src/tts/gtts.py
@@ -7,7 +7,7 @@ from gtts import gTTS, lang
 from dialect.tts.basetts import TextToSpeechBase, TextToSpeechError
 
 
-class GTextToSpeech(TextToSpeechBase):
+class TextToSpeech(TextToSpeechBase):
     name = 'google'
     prettyname = 'Google Text-to-Speech'
     languages = []

--- a/src/tts/gtts.py
+++ b/src/tts/gtts.py
@@ -23,4 +23,3 @@ class GTextToSpeech(TextToSpeechBase):
 
         except Exception as exc:
             raise TextToSpeechError(exc) from exc
-        

--- a/src/tts/meson.build
+++ b/src/tts/meson.build
@@ -1,8 +1,0 @@
-# Python sources
-sources = [
-  '__init__.py',
-  'basetts.py',
-  'gtts.py'
-]
-# Install sources
-install_data(sources, install_dir: join_paths(moduledir, 'tts'))

--- a/src/window.py
+++ b/src/window.py
@@ -146,7 +146,7 @@ class DialectWindow(Handy.ApplicationWindow):
             daemon=True
         ).start()
         # Get languages available for speech
-        if Settings.get().tts:
+        if Settings.get().tts != '':
             threading.Thread(target=self.load_lang_speech, daemon=True).start()
 
     def load_translator(self, backend, launch=False):
@@ -263,7 +263,7 @@ class DialectWindow(Handy.ApplicationWindow):
         """
         try:
             self.voice_loading = True
-            self.tts = TTS[Settings.get().tts_value - 1]()
+            self.tts = TTS[Settings.get().tts]()
             self.tts_langs = self.tts.languages
             if not listen:
                 GLib.idle_add(self.toggle_voice_spinner, False)
@@ -360,8 +360,8 @@ class DialectWindow(Handy.ApplicationWindow):
 
         self.toggle_voice_spinner(True)
 
-        self.src_voice_btn.set_visible(Settings.get().tts)
-        self.dest_voice_btn.set_visible(Settings.get().tts)
+        self.src_voice_btn.set_visible(Settings.get().tts != '')
+        self.dest_voice_btn.set_visible(Settings.get().tts != '')
 
     def responsive_listener(self, _window):
         size = self.get_size()
@@ -485,7 +485,7 @@ class DialectWindow(Handy.ApplicationWindow):
             self.dest_lang_selector.set_property('selected', self.src_langs[0])
 
         # Disable or enable listen function.
-        if self.tts_langs and Settings.get().tts:
+        if self.tts_langs and Settings.get().tts != '':
             self.src_voice_btn.set_sensitive(code in self.tts_langs
                                          and src_text != '')
 
@@ -530,7 +530,7 @@ class DialectWindow(Handy.ApplicationWindow):
             self.src_lang_selector.set_property('selected', self.dest_langs[0])
 
         # Disable or enable listen function.
-        if self.tts_langs and Settings.get().tts:
+        if self.tts_langs and Settings.get().tts != '':
             self.dest_voice_btn.set_sensitive(code in self.tts_langs
                                          and dest_text != '')
 

--- a/src/window.py
+++ b/src/window.py
@@ -7,13 +7,13 @@ import threading
 from gettext import gettext as _
 from tempfile import NamedTemporaryFile
 
-from gi.repository import Gdk, GLib, GObject, Gtk, Gst, Handy
+from gi.repository import Gdk, GLib, GObject, Gst, Gtk, Handy
 
-from dialect.define import APP_ID, RES_PATH, MAX_LENGTH, TRANS_NUMBER
+from dialect.define import APP_ID, MAX_LENGTH, RES_PATH, TRANS_NUMBER
 from dialect.lang_selector import DialectLangSelector
+from dialect.settings import Settings
 from dialect.translators import TRANSLATORS
 from dialect.tts import TTS
-from dialect.settings import Settings
 
 
 @Gtk.Template(resource_path=f'{RES_PATH}/window.ui')

--- a/src/window.py
+++ b/src/window.py
@@ -126,9 +126,8 @@ class DialectWindow(Handy.ApplicationWindow):
 
         # Load saved dark mode
         gtk_settings = Gtk.Settings.get_default()
-        dark_mode = Settings.get().get_boolean('dark-mode')
         gtk_settings.set_property('gtk-application-prefer-dark-theme',
-                                  dark_mode)
+                                  Settings.get().dark_mode)
 
         # Connect responsive design function
         self.connect('check-resize', self.responsive_listener)
@@ -141,12 +140,13 @@ class DialectWindow(Handy.ApplicationWindow):
 
         # Load translator
         self.retry_backend_btn.connect('clicked', self.retry_load_translator)
-        threading.Thread(target=self.load_translator,
-                         args=[Settings.get().get_int('backend'), True],
-                         daemon=True
+        threading.Thread(
+            target=self.load_translator,
+            args=[Settings.get().backend, True],
+            daemon=True
         ).start()
         # Get languages available for speech
-        if bool(Settings.get().get_int('tts')):
+        if Settings.get().tts:
             threading.Thread(target=self.load_lang_speech, daemon=True).start()
 
     def load_translator(self, backend, launch=False):
@@ -165,7 +165,7 @@ class DialectWindow(Handy.ApplicationWindow):
             self.src_lang_selector.set_languages(self.translator.languages)
             self.dest_lang_selector.set_languages(self.translator.languages)
             # Update selected langs
-            src_lang_default = 'auto' if Settings.get().get_boolean('src-auto') else self.src_langs[0]
+            src_lang_default = 'auto' if Settings.get().src_auto else self.src_langs[0]
             self.src_lang_selector.set_property('selected', src_lang_default)
             self.dest_lang_selector.set_property('selected', self.dest_langs[0])
 
@@ -179,17 +179,16 @@ class DialectWindow(Handy.ApplicationWindow):
 
         try:
             # Translator object
-            translators = list(TRANSLATORS.values())
-            if translators[backend].supported_features['change-instance']:
-                self.translator = translators[backend](
-                    base_url=Settings.get().get_string(f'{translators[backend].name}-instance')
+            if TRANSLATORS[backend].supported_features['change-instance']:
+                self.translator = TRANSLATORS[backend](
+                    base_url=Settings.get().get_instance_url(TRANSLATORS[backend].name)
                 )
             else:
-                self.translator = translators[backend]()
+                self.translator = TRANSLATORS[backend]()
 
             # Get saved languages
-            self.src_langs = list(Settings.get().get_value(f'{self.translator.name}-src-langs'))
-            self.dest_langs = list(Settings.get().get_value(f'{self.translator.name}-dest-langs'))
+            self.src_langs = Settings.get().get_src_langs(self.translator.name)
+            self.dest_langs = Settings.get().get_dest_langs(self.translator.name)
 
             # Update UI
             GLib.idle_add(update_ui)
@@ -215,7 +214,7 @@ class DialectWindow(Handy.ApplicationWindow):
 
     def retry_load_translator(self, _button):
         threading.Thread(target=self.load_translator,
-                         args=[Settings.get().get_int('backend')],
+                         args=[Settings.get().backend],
                          daemon=True
         ).start()
 
@@ -264,7 +263,7 @@ class DialectWindow(Handy.ApplicationWindow):
         """
         try:
             self.voice_loading = True
-            self.tts = TTS[Settings.get().get_int('tts') - 1]()
+            self.tts = TTS[Settings.get().tts_value - 1]()
             self.tts_langs = self.tts.languages
             if not listen:
                 GLib.idle_add(self.toggle_voice_spinner, False)
@@ -361,8 +360,8 @@ class DialectWindow(Handy.ApplicationWindow):
 
         self.toggle_voice_spinner(True)
 
-        self.src_voice_btn.set_visible(bool(Settings.get().get_int('tts')))
-        self.dest_voice_btn.set_visible(bool(Settings.get().get_int('tts')))
+        self.src_voice_btn.set_visible(Settings.get().tts)
+        self.dest_voice_btn.set_visible(Settings.get().tts)
 
     def responsive_listener(self, _window):
         size = self.get_size()
@@ -417,10 +416,8 @@ class DialectWindow(Handy.ApplicationWindow):
 
     def save_translator_settings(self, *args, **kwargs):
         if self.translator is not None:
-            Settings.get().set_value(f'{self.translator.name}-src-langs',
-                                    GLib.Variant('as', self.src_langs))
-            Settings.get().set_value(f'{self.translator.name}-dest-langs',
-                                    GLib.Variant('as', self.dest_langs))
+            Settings.get().set_src_langs(self.translator.name, self.src_langs)
+            Settings.get().set_dest_langs(self.translator.name, self.dest_langs)
 
     def send_notification(self, text, timeout=5):
         """
@@ -488,7 +485,7 @@ class DialectWindow(Handy.ApplicationWindow):
             self.dest_lang_selector.set_property('selected', self.src_langs[0])
 
         # Disable or enable listen function.
-        if self.tts_langs and bool(Settings.get().get_int('tts')):
+        if self.tts_langs and Settings.get().tts:
             self.src_voice_btn.set_sensitive(code in self.tts_langs
                                          and src_text != '')
 
@@ -533,7 +530,7 @@ class DialectWindow(Handy.ApplicationWindow):
             self.src_lang_selector.set_property('selected', self.dest_langs[0])
 
         # Disable or enable listen function.
-        if self.tts_langs and bool(Settings.get().get_int('tts')):
+        if self.tts_langs and Settings.get().tts:
             self.dest_voice_btn.set_sensitive(code in self.tts_langs
                                          and dest_text != '')
 
@@ -732,15 +729,15 @@ class DialectWindow(Handy.ApplicationWindow):
                 modifiers in (shift_mask, 0) and not self.src_text.is_focus()):
             self.src_text.grab_focus()
 
-        if not Settings.get().get_boolean('live-translation'):
+        if not Settings.get().live_translation:
             if control_mask == modifiers:
                 if keyboard.keyval == Gdk.KEY_Return:
-                    if not Settings.get().get_value('translate-accel'):
+                    if not Settings.get().translate_accel_value:
                         self.translation(button)
                         return Gdk.EVENT_STOP
                     return Gdk.EVENT_PROPAGATE
             elif keyboard.keyval == Gdk.KEY_Return:
-                if Settings.get().get_value('translate-accel'):
+                if Settings.get().translate_accel_value:
                     self.translation(button)
                     return Gdk.EVENT_STOP
                 return Gdk.EVENT_PROPAGATE
@@ -788,7 +785,7 @@ class DialectWindow(Handy.ApplicationWindow):
             )
             self.src_buffer.set_text(src_text[:MAX_LENGTH])
         self.char_counter.set_text(f'{str(buffer.get_char_count())}/{MAX_LENGTH}')
-        if Settings.get().get_boolean('live-translation'):
+        if Settings.get().live_translation:
             self.translation(None)
 
     # The history part
@@ -894,7 +891,7 @@ class DialectWindow(Handy.ApplicationWindow):
                 self.mistakes.set_revealed(False)
 
         def on_pronunciation():
-            reveal = Settings.get().get_boolean('show-pronunciation')
+            reveal = Settings.get().show_pronunciation
             if self.translator.supported_features['pronunciation']:
                 if self.trans_src_pron is not None:
                     self.src_pron_label.set_text(self.trans_src_pron)

--- a/src/window.py
+++ b/src/window.py
@@ -180,12 +180,13 @@ class DialectWindow(Handy.ApplicationWindow):
 
         try:
             # Translator object
-            if TRANSLATORS[backend].supported_features['change-instance']:
-                self.translator = TRANSLATORS[backend](
-                    base_url=self.settings.get_string(f'{TRANSLATORS[backend].name}-instance')
+            translators = list(TRANSLATORS.values())
+            if translators[backend].supported_features['change-instance']:
+                self.translator = translators[backend](
+                    base_url=self.settings.get_string(f'{translators[backend].name}-instance')
                 )
             else:
-                self.translator = TRANSLATORS[backend]()
+                self.translator = translators[backend]()
 
             # Get saved languages
             self.src_langs = list(self.settings.get_value(f'{self.translator.name}-src-langs'))


### PR DESCRIPTION
This initial code should allow us to load dynamically the translation backends.

Currently it only will save us some time when adding a new backend (which doesn't a common task) so I don't know if we will make it reach `main`. But it will help a bit when playing around with experimental backends.

ToDo:
- [x] Update `backend` gsetting to store a string
- [x] Don't convert `TRANSLATORS` to a list, and access it using the new gsetting
- [x] Save the recent langs with a `a{sas}` type, so we don't have to create new gsettings for each backend:
     Example: ```{"google": ["en", "fr", "es", "de"]}```
    And make each backend load it's default values to it if they key doesn't exist?
- [x] Do something to migrate the old gsettings values
- [x] Make TTS use the same system
